### PR TITLE
Fixes crash on Pre-21

### DIFF
--- a/app-rating/src/main/res/layout/star_button_layout.xml
+++ b/app-rating/src/main/res/layout/star_button_layout.xml
@@ -1,11 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
-<merge xmlns:android="http://schemas.android.com/apk/res/android">
+<merge
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <ImageView
         android:id="@+id/empty_star_image_view"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:src="@drawable/ic_star_empty_48dp" />
+        app:srcCompat="@drawable/ic_star_empty_48dp"/>
 
 
     <ImageView
@@ -13,6 +15,6 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:alpha="0"
-        android:src="@drawable/ic_star_full_48dp" />
+        app:srcCompat="@drawable/ic_star_full_48dp"/>
 
 </merge>


### PR DESCRIPTION
Currently this library crashes on me on < Api-Level 21 because of the use of android:src attribute with vectordrawables.

This change will fix the issue.

@pglebocki 